### PR TITLE
Fix docker error

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -51,7 +51,7 @@ WORKDIR /opt
 # setup user
 # TODO: one limitation of this apporach is that the user id is fixed (it needs to match the host user ID which is done automatically in `build.sh`), which makes this container less portable for built images running on different machines with different user IDs. This is because user ID has to match when so that files mounted in the Docker container can be properly accessed. To fix this, you could use https://github.com/boxboat/fixuid
 ARG USERID=1000
-RUN useradd -u $USERID --create-home $USERNAME
+RUN useradd -l -u $USERID --create-home $USERNAME
 ENV PATH="/home/$USERNAME/.local/bin:$PATH"
 
 # IsaacGymEnvs clone and change permissions so user can pip install


### PR DESCRIPTION
Hey, thanks for making this repo so easy to use!

There's a tiny error in the Dockerfile where if the user running `build.sh` has a large userid, the exported image will add all users from 0 to userid and take an extremely long time to export layers at the end. See for example: https://github.com/docker/cli/issues/3559

The easy fix for this is to just use the `-l` flag when adding a new user. That fixed this issue for me.